### PR TITLE
Adding support for local option, passed as an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,13 @@
 'use strict';
-module.exports = function (date) {
-	return (date || new Date()).toISOString().replace(/T/, ' ').replace(/\..+/, ' UTC');
+module.exports = function(date, local) {
+	local = local ? local : date ? date instanceof Date ? null : date : null;
+	date = date ? date instanceof Date ? date : new Date() : new Date();
+	var prettyTimeZone = ' UTC';
+	if (local) {
+		prettyTimeZone = (new Date().toString().match(/GMT\S*/).toString().slice(0, 6) + ":" + new Date().toString().match(/GMT\S*/).toString().slice(6)).replace(/GMT/, "");
+		prettyTimeZone = prettyTimeZone.charAt(1) !== "0" ? prettyTimeZone : prettyTimeZone.slice(0, 1) + prettyTimeZone.slice(2);
+		prettyTimeZone = prettyTimeZone.split(":")[1] === "00" ? prettyTimeZone.split(":")[0] : prettyTimeZone;
+		prettyTimeZone = ' UTC'+ prettyTimeZone;
+	}
+	return date.toISOString().replace(/T/, ' ').replace(/\..+/, prettyTimeZone);
 };

--- a/readme.md
+++ b/readme.md
@@ -16,21 +16,32 @@ $ npm install --save date-time
 const dateTime = require('date-time');
 
 dateTime();
-//=> '2014-01-09 06:46:01 UTC'
+//=> '2016-07-19 12:07:08 UTC'
 
-dateTime(new Date(2050, 1, 2));
-//=> '2050-02-01 23:00:00 UTC'
+dateTime('local');
+//=> '2016-07-19 12:07:08 UTC+5:30'
+
+dateTime(new Date(1994, 7, 3));
+//=> '1994-08-02 18:30:00 UTC'
+
+dateTime(new Date(1994, 7, 3), 'local');
+//=> '1994-08-02 18:30:00 UTC+5:30'
 ```
 
 
 ## API
 
-### dateTime([date])
+### dateTime([date],'local'])
 
 #### date
 
 Type: `date`  
 Default: `new Date()`
+
+#### date
+
+Type: `string`  
+Default: null
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -2,6 +2,22 @@
 var assert = require('assert');
 var dateTime = require('./');
 
-it('should print out pretty datetime', function () {
+it('should print out UTC datetime', function () {
 	assert(/UTC$/.test(dateTime()));
+	console.log(dateTime());
+});
+
+it('should print out local datetime', function(){
+	assert(/(UTC[\+\-][1-9][0-9]?(:30)?$)|(UTC[\+\-]0$)/.test(dateTime('local')));
+	console.log(dateTime(true));
+});
+
+it('should print out UTC datetime of August 2, 1994', function(){
+	assert(/UTC$/.test(dateTime(new Date(1994, 7 ,3))));
+	console.log(dateTime(new Date(1994, 7, 3)));
+});
+
+it('should print out local datetime of August 2, 1994', function(){
+	assert(/(UTC[\+\-][1-9][0-9]?(:30)?$)|(UTC[\+\-]0$)/.test(dateTime(new Date(1994, 7, 3), 'local')));
+	console.log(dateTime(new Date(1994, 7, 3), 'local'));
 });


### PR DESCRIPTION
Replaced the ```date``` as an object which can have ```date``` and a boolean ```local``` which can be set to true to display the date in format **UTC+/-hhMM**